### PR TITLE
add apt-get clean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN    apt-get --yes update; apt-get --yes upgrade; apt-get --yes install softwa
 RUN    sudo apt-add-repository --yes ppa:webupd8team/java; apt-get --yes update
 RUN    echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections  && \
        echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections  && \
-       apt-get --yes install curl oracle-java8-installer
+       apt-get --yes install curl oracle-java8-installer ; apt-get clean
 
 
 # Load in all of our config files.


### PR DESCRIPTION
Added apt-get clean to the third RUN command.
If you throw an apt-get clean at the end, it will clean up the apt cache and reduce the size of your image a bit.