### PR TITLE
Upgrade to minecraft 1.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/data/
+data/**
+!data/*.md

--- a/README.md
+++ b/README.md
@@ -4,46 +4,31 @@ A nice and easy way to get a Minecraft server up and running using docker. For
 help on getting started with docker see the [official getting started guide][0].
 For more information on Minecraft and check out it's [website][1].
 
+This repository is a fork from https://github.com/overshard/docker-minecraft
 
-## Building docker-minecraft
+## Running this image
 
 Running this will build you a docker image with the latest version of both
-docker-minecraft and Minecraft itself.
+docker-minecraft and Minecraft itself. 
 
-    git clone https://github.com/overshard/docker-minecraft
+    git clone https://github.com/nicemd/docker-minecraft
     cd docker-minecraft
-    sudo docker build -t overshard/minecraft .
+    docker-compose up
+
+The Docker image is built on your computer and not downloaded from Docker hub.
+
+## Running this image in a Docker Swarm
+
+Only one swarm replica of the server is supported.
 
 
-## Running docker-minecraft
+    git clone https://github.com/nicemd/docker-minecraft
+    cd docker-minecraft
+    docker stack deploy -c docker-compose.yml minecraft
 
-Running the first time will set your port to a static port of your choice so
-that you can easily map a proxy to. If this is the only thing running on your
-system you can map the port to 25565 and no proxy is needed. i.e.
-`-p=25565:25565` . If you want to enable the query protocol you need
-to add another -p=25565:25565/udp to forward the UDP protocol on the
-same port as well.
-Also be sure your mounted directory on your host machine is
-already created before running `mkdir -p /mnt/minecraft`.
+## Minecraft Data directory
 
-    sudo docker run -d=true -p=25565:25565 -v=/mnt/minecraft:/data overshard/minecraft /start
-
-From now on when you start/stop docker-minecraft you should use the container id
-with the following commands. To get your container id, after you initial run
-type `sudo docker ps` and it will show up on the left side followed by the
-image name which is `overshard/minecraft:latest`.
-
-    sudo docker start <container_id>
-    sudo docker stop <container_id>
-
-
-### Notes on the run command
-
- + `-v` is the volume you are mounting `-v=host_dir:docker_dir`
- + `overshard/minecraft` is simply what I called my docker build of this image
- + `-d=true` allows this to run cleanly as a daemon, remove for debugging
- + `-p` is the port it connects to, `-p=host_port:docker_port`
-
+Your Minecraft world data will be placed in the `data` directory.
 
 [0]: http://www.docker.io/gettingstarted/
 [1]: http://minecraft.net/

--- a/README.md
+++ b/README.md
@@ -6,29 +6,43 @@ For more information on Minecraft and check out it's [website][1].
 
 This repository is a fork from https://github.com/overshard/docker-minecraft
 
-## Running this image
+## Running
+### Running this image with Docker-Compose
 
-Running this will build you a docker image with the latest version of both
-docker-minecraft and Minecraft itself. 
+```
+git clone https://github.com/nicemd/docker-minecraft
+cd docker-minecraft
+docker-compose up
+```
+Note you need docker-compose v1.21 or later.
 
-    git clone https://github.com/nicemd/docker-minecraft
-    cd docker-minecraft
-    docker-compose up
+### Running this image in a Docker Swarm
+Only one swarm replica of the Minecraft server is supported.
 
-The Docker image is built on your computer and not downloaded from Docker hub.
-
-## Running this image in a Docker Swarm
-
-Only one swarm replica of the server is supported.
-
-
-    git clone https://github.com/nicemd/docker-minecraft
-    cd docker-minecraft
-    docker stack deploy -c docker-compose.yml minecraft
-
+```
+git clone https://github.com/nicemd/docker-minecraft
+cd docker-minecraft
+docker stack deploy -c docker-compose.yml minecraft
+```
 ## Minecraft Data directory
 
 Your Minecraft world data will be placed in the `data` directory.
 
+
+## Building docker image
+```
+docker build -t niemd/docker-minecraft .
+docker tag niemd/docker-minecraft:latest niemd/docker-minecraft:1.12.2
+```
+
+Push it to Docker hub
+```
+docker push niemd/docker-minecraft:latest
+docker push niemd/docker-minecraft:1.12.2
+```
+
+
 [0]: http://www.docker.io/gettingstarted/
 [1]: http://minecraft.net/
+
+

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,4 @@
+# Place holder directory #
+
+Here is where your minecraft data will be placed
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  minecraft:
+    build: .
+    volumes:
+      - ./data:/data
+    ports:
+      - 25565:25565

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   minecraft:
-    build: .
+    image: niemd/docker-minecraft:1.12.2
     volumes:
       - ./data:/data
     ports:

--- a/scripts/start
+++ b/scripts/start
@@ -7,10 +7,11 @@
 # -----------------------------------------------------------------------------
 
 
-if [ ! -f /data/minecraft_server.jar ]
+if [ ! -f /data/minecraft_server.1.12.jar ]
 then
-    curl "https://s3.amazonaws.com/Minecraft.Download/versions/1.11.2/minecraft_server.1.11.2.jar" -o /data/minecraft_server.jar
+    curl "https://s3.amazonaws.com/Minecraft.Download/versions/1.12/minecraft_server.1.12.jar" -o /data/minecraft_server.1.12.jar
 fi
+cp -f /data/minecraft_server.1.12.jar /data/minecraft_server.jar
 
 if [ ! -f /data/eula.txt ]
 then

--- a/scripts/start
+++ b/scripts/start
@@ -3,15 +3,15 @@
 # docker-minecraft /start script
 #
 # Authors: Isaac Bythewood
-# Updated: Dec 14th, 2014
+# Updated: Apr 13th, 2018
 # -----------------------------------------------------------------------------
 
-
-if [ ! -f /data/minecraft_server.1.12.jar ]
+if [ ! -f /data/minecraft_server.1.12.2.jar ]
 then
-    curl "https://s3.amazonaws.com/Minecraft.Download/versions/1.12/minecraft_server.1.12.jar" -o /data/minecraft_server.1.12.jar
+    echo Downloading Minecraft
+    curl "https://s3.amazonaws.com/Minecraft.Download/versions/1.12.2/minecraft_server.1.12.2.jar" -o /data/minecraft_server.1.12.2.jar
 fi
-cp -f /data/minecraft_server.1.12.jar /data/minecraft_server.jar
+cp -f /data/minecraft_server.1.12.2.jar /data/minecraft_server.jar
 
 if [ ! -f /data/eula.txt ]
 then


### PR DESCRIPTION
Upgrade to minecraft 1.12

Also changed so the downloaded minecraft_server.1.12.jar is downloaded with version number still in filename and then copied by start script to minecraft_server.jar. This means the server can be upgraded without manually deleting /data/minecraft_server.jar.
